### PR TITLE
Load Entities and Assertions from OWL file

### DIFF
--- a/CONSERT-IDE/src/org/aimas/consert/ide/model/WorkspaceModel.java
+++ b/CONSERT-IDE/src/org/aimas/consert/ide/model/WorkspaceModel.java
@@ -219,11 +219,10 @@ public class WorkspaceModel {
 								TextFileDocumentProvider provider = new TextFileDocumentProvider();
 								IDocument document = provider.getDocument(fileResources[k]);
 								ProjectModel pm = projects.get(projectName);
-								populateProjectModel(pm, document, (IFile) fileResources[k]);
-								
 								File OWLfile = resource.getFile("consert.owl").getLocation().toFile();
 								File TTLfile = resource.getFile("consert.ttl").getLocation().toFile();
 								pm.initializeOWLModel(OWLfile,TTLfile);
+								populateProjectModel(pm, document, (IFile) fileResources[k]);
 							}
 						}
 
@@ -275,7 +274,12 @@ public class WorkspaceModel {
 		}
 	}
 
-	private void populateProjectModel(ProjectModel projectModel, IDocument document, IFile file)
+	private void populateProjectModel(ProjectModel projectModel, IDocument document, IFile file) {
+		projectModel.loadEntities();
+		projectModel.loadAssertions();
+	}
+	
+	private void populateProjectModelOld(ProjectModel projectModel, IDocument document, IFile file)
 			throws JsonProcessingException, IOException, CoreException {
 
 		/* get string content from file, first refreshed on disk */

--- a/CONSERT-IDE/src/org/aimas/consert/ide/util/OWLUtils.java
+++ b/CONSERT-IDE/src/org/aimas/consert/ide/util/OWLUtils.java
@@ -33,10 +33,19 @@ public class OWLUtils {
 	 public static String binaryContextAssertion = "BinaryContextAssertion";
 	 public static String contextAnnotation = "ContextAnnotation";
 	 public static String entityDescription = "EntityDescription";
+	 public static String assertionSubject = "assertionSubject";
+	 public static String assertionObject = "assertionObject";
+	 public static String assertionAcquisitionType = "assertionAcquisitionType";
 	 public static IRI iricontextEntity= IRI.create(OWLUtils.coreURI + OWLUtils.contextEntity);
 	 public static IRI iriBinaryContextAssertion= IRI.create(OWLUtils.coreURI + OWLUtils.binaryContextAssertion);
 	 public static IRI iriContextAnnotation= IRI.create(OWLUtils.coreURI + OWLUtils.contextAnnotation);
 	 public static IRI iriEntityDescription= IRI.create(OWLUtils.coreURI + OWLUtils.entityDescription);
+	 public static IRI iriAssertionSubject= IRI.create(OWLUtils.coreURI + OWLUtils.assertionSubject);
+	 public static IRI iriAssertionObject= IRI.create(OWLUtils.coreURI + OWLUtils.assertionObject);
+	 public static IRI iriAssertionAcquisitionTypet= IRI.create(OWLUtils.coreURI + OWLUtils.assertionAcquisitionType);
+	 
+	 public static final String label = "label";
+	 public static final String comment = "comment";
 	 
 	 
 	 public static Set<OWLClassExpression> getSuperClasses(OWLClass subCls, OWLOntology ont) {
@@ -84,5 +93,36 @@ public class OWLUtils {
 			}
 			return annotations;
 		}
+	    
+	    /**
+	     * Returns the term type.
+	     *
+	     * @param annotation the annotation
+	     * @return the term type
+	     */
+	    public static String getName(OWLAnnotation annotation) {
+	      return getTerminologyId(annotation.getProperty().getIRI());
+	    }
+	    
+	    /**
+	     * Returns the terminology id.
+	     *
+	     * @param iri the iri
+	     * @return the terminology id
+	     */
+	    
+	    public static String getTerminologyId(IRI iri) {
+
+	      if (iri.toString().contains("#")) {
+	        // everything after the last #
+	        return iri.toString().substring(iri.toString().lastIndexOf("#") + 1);
+	      } else if (iri.toString().contains("/")) {
+	        // everything after the last slash
+	        return iri.toString().substring(iri.toString().lastIndexOf("/") + 1);
+	      }
+	      // otherwise, just return the iri
+	      return iri.toString();
+	    }
+
 
 }


### PR DESCRIPTION

- [x] load ContextEntities

- [x] load ContextAssertions

Note: 

- First implementation

- Currently all other context elements are not loaded because of the transition from JSON to OWL file
- Import declarations currently commented until solving issue to load from local file
- To test functionality:  delete all projects in workspace; create new CONSERT project; add Entities and Assertions, go to Tree View and click the option "Save.." ; close IDE; reopen IDE and see entities and Assertions appear in Tree View